### PR TITLE
Package renamed to react-native-mds-movesense

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,9 +23,9 @@ The [example app](/example/) demonstrates usage of the library. You need to run 
 
 It is configured to use the local version of the library, so any changes you make to the library's source code will be reflected in the example app. Changes to the library's JavaScript code will be reflected in the example app without a rebuild, but native code changes will require a rebuild of the example app.
 
-If you want to use Android Studio or XCode to edit the native code, you can open the `example/android` or `example/ios` directories respectively in those editors. To edit the Objective-C or Swift files, open `example/ios/MovesenseExample.xcworkspace` in XCode and find the source files at `Pods > Development Pods > react-native-movesense`.
+If you want to use Android Studio or XCode to edit the native code, you can open the `example/android` or `example/ios` directories respectively in those editors. To edit the Objective-C or Swift files, open `example/ios/MovesenseExample.xcworkspace` in XCode and find the source files at `Pods > Development Pods > react-native-mds-movesense`.
 
-To edit the Java or Kotlin files, open `example/android` in Android studio and find the source files at `react-native-movesense` under `Android`.
+To edit the Java or Kotlin files, open `example/android` in Android studio and find the source files at `react-native-mds-movesense` under `Android`.
 
 You can use various commands from the root directory to work with the project.
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# react-native-movesense
+# react-native-mds-movesense
 
 React native wrapper for [movesense](https://www.movesense.com/movesense-active/) library.
 
@@ -9,7 +9,7 @@ This library currently supports only Android but not iOS. I have little experien
 ## Installation
 
 ```sh
-npm install react-native-movesense
+npm install react-native-mds-movesense
 ```
 
 ## Android permissions
@@ -33,7 +33,7 @@ import RNMovesense, {
     type MovesenseReadyDevice,
     type MovesenseDevice,
     type MovesenseScannedDevice,
-} from 'react-native-movesense';
+} from 'react-native-mds-movesense';
 
 // ...
 
@@ -67,7 +67,7 @@ where:
 
 To find more informations about the `contract` parameter check the [documentation](https://www.movesense.com/docs/esw/api_reference/).
 
-> For a more comprehensive example, check out the [example app](https://github.com/ferdiu/react-native-movesense/blob/main/example/src/App.tsx).
+> For a more comprehensive example, check out the [example app](https://github.com/ferdiu/react-native-mds-movesense/blob/main/example/src/App.tsx).
 
 ### Events
 
@@ -126,7 +126,7 @@ eventEmitter.removeAllListeners('Notification');
 eventEmitter.removeAllListeners('NotificationError');
 ```
 
-> For a more comprehensive example, check out the [example app](https://github.com/ferdiu/react-native-movesense/blob/main/example/src/App.tsx).
+> For a more comprehensive example, check out the [example app](https://github.com/ferdiu/react-native-mds-movesense/blob/main/example/src/App.tsx).
 
 ## Contributing
 

--- a/example/package.json
+++ b/example/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "react-native-movesense-example",
+  "name": "react-native-mds-movesense-example",
   "version": "0.0.1",
   "private": true,
   "scripts": {

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -18,7 +18,7 @@ import RNMovesense, {
     type NotificationErrorEvent,
     type NotificationEvent,
     type MovesenseScannedDevice,
-} from 'react-native-movesense';
+} from 'react-native-mds-movesense';
 
 // Emitter
 import { NativeEventEmitter, NativeModules } from 'react-native';

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "react-native-movesense",
+  "name": "react-native-mds-movesense",
   "version": "0.1.0",
   "description": "React native wrapper for movesense library",
   "main": "lib/commonjs/index",
@@ -26,7 +26,7 @@
     "!**/.*"
   ],
   "scripts": {
-    "example": "yarn workspace react-native-movesense-example",
+    "example": "yarn workspace react-native-mds-movesense-example",
     "test": "jest",
     "typecheck": "tsc --noEmit",
     "lint": "eslint \"**/*.{js,ts,tsx}\"",
@@ -41,14 +41,14 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/ferdiu/react-native-movesense.git"
+    "url": "git+https://github.com/ferdiu/react-native-mds-movesense.git"
   },
   "author": "Federico Manzella <ferdiu.manzella@gmail.com> (https://github.com/ferdiu)",
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/ferdiu/react-native-movesense/issues"
+    "url": "https://github.com/ferdiu/react-native-mds-movesense/issues"
   },
-  "homepage": "https://github.com/ferdiu/react-native-movesense#readme",
+  "homepage": "https://github.com/ferdiu/react-native-mds-movesense#readme",
   "publishConfig": {
     "registry": "https://registry.npmjs.org/"
   },

--- a/react-native-mds-movesense.podspec
+++ b/react-native-mds-movesense.podspec
@@ -4,7 +4,7 @@ package = JSON.parse(File.read(File.join(__dir__, "package.json")))
 folly_compiler_flags = '-DFOLLY_NO_CONFIG -DFOLLY_MOBILE=1 -DFOLLY_USE_LIBCPP=1 -Wno-comma -Wno-shorten-64-to-32'
 
 Pod::Spec.new do |s|
-  s.name         = "react-native-movesense"
+  s.name         = "react-native-mds-movesense"
   s.version      = package["version"]
   s.summary      = package["description"]
   s.homepage     = package["homepage"]
@@ -12,7 +12,7 @@ Pod::Spec.new do |s|
   s.authors      = package["author"]
 
   s.platforms    = { :ios => min_ios_version_supported }
-  s.source       = { :git => "https://github.com/ferdiu/react-native-movesense.git", :tag => "#{s.version}" }
+  s.source       = { :git => "https://github.com/ferdiu/react-native-mds-movesense.git", :tag => "#{s.version}" }
 
   s.source_files = "ios/**/*.{h,m,mm,swift}"
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -6,7 +6,7 @@ import {
 } from './types/events';
 
 const LINKING_ERROR =
-    `The package 'react-native-movesense' doesn't seem to be linked. Make sure: \n\n` +
+    `The package 'react-native-mds-movesense' doesn't seem to be linked. Make sure: \n\n` +
     Platform.select({ ios: "- You have run 'pod install'\n", default: '' }) +
     '- You rebuilt the app after installing the package\n' +
     '- You are not using Expo Go\n';

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "rootDir": ".",
     "paths": {
-      "react-native-movesense": ["./src/index"]
+      "react-native-mds-movesense": ["./src/index"]
     },
     "allowUnreachableCode": false,
     "allowUnusedLabels": false,

--- a/yarn.lock
+++ b/yarn.lock
@@ -11035,9 +11035,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-native-movesense-example@workspace:example":
+"react-native-mds-movesense-example@workspace:example":
   version: 0.0.0-use.local
-  resolution: "react-native-movesense-example@workspace:example"
+  resolution: "react-native-mds-movesense-example@workspace:example"
   dependencies:
     "@babel/core": ^7.20.0
     "@babel/preset-env": ^7.20.0
@@ -11052,9 +11052,9 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"react-native-movesense@workspace:.":
+"react-native-mds-movesense@workspace:.":
   version: 0.0.0-use.local
-  resolution: "react-native-movesense@workspace:."
+  resolution: "react-native-mds-movesense@workspace:."
   dependencies:
     "@commitlint/config-conventional": ^17.0.2
     "@evilmartians/lefthook": ^1.5.0


### PR DESCRIPTION
The package was renamed to `react-native-mds-movesense` due to conflicting name with another old package with the same name on npmjs.